### PR TITLE
feat: add Device DTOs and implement DeviceService with CRUD operations

### DIFF
--- a/src/dtos/device-input.dto.ts
+++ b/src/dtos/device-input.dto.ts
@@ -1,0 +1,40 @@
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { DeviceStatus } from '../entities/peripheral-device.entity';
+
+export class CreateDeviceDto {
+  @IsNumber()
+  @IsNotEmpty()
+  uid: number;
+
+  @IsString()
+  @IsNotEmpty()
+  vendor: string;
+
+  @IsOptional()
+  @IsEnum(DeviceStatus)
+  status?: DeviceStatus;
+
+  @IsNumber()
+  device_type_id: number;
+}
+
+export class UpdateDeviceDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  vendor?: string;
+
+  @IsOptional()
+  @IsEnum(DeviceStatus)
+  status?: DeviceStatus;
+
+  @IsOptional()
+  @IsNumber()
+  device_type_id?: number;
+}

--- a/src/dtos/device-response.dto.ts
+++ b/src/dtos/device-response.dto.ts
@@ -1,0 +1,30 @@
+import { DeviceStatus } from '../entities/peripheral-device.entity';
+
+export class DeviceResponseDto {
+  id: string;
+  uid: number;
+  vendor: string;
+  status: DeviceStatus;
+  created_at: Date;
+  last_seen_at?: Date;
+  gateway_id?: string;
+  device_type_id: number;
+}
+
+export class DeviceWithTypeResponseDto extends DeviceResponseDto {
+  device_type?: {
+    id: number;
+    name: string;
+    description?: string;
+  };
+}
+
+export class DeviceWithGatewayResponseDto extends DeviceResponseDto {
+  gateway?: {
+    id: string;
+    name: string;
+    serial_number: string;
+    ipv4_address: string;
+    status: string;
+  };
+}

--- a/src/dtos/index.ts
+++ b/src/dtos/index.ts
@@ -1,2 +1,4 @@
 export * from './gateway-input.dto';
 export * from './gateway-response.dto';
+export * from './device-input.dto';
+export * from './device-response.dto';

--- a/src/services/device.service.ts
+++ b/src/services/device.service.ts
@@ -1,0 +1,135 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CreateDeviceDto, UpdateDeviceDto, DeviceResponseDto } from 'src/dtos';
+import { DeviceType, PeripheralDevice } from 'src/entities';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class DeviceService {
+  constructor(
+    @InjectRepository(PeripheralDevice)
+    private deviceRepository: Repository<PeripheralDevice>,
+    @InjectRepository(DeviceType)
+    private deviceTypeRepository: Repository<DeviceType>,
+  ) {}
+
+  async addDevice(
+    createDeviceDto: CreateDeviceDto,
+  ): Promise<DeviceResponseDto> {
+    try {
+      const existingDevice = await this.deviceRepository.findOne({
+        where: { uid: createDeviceDto.uid },
+      });
+      if (existingDevice) {
+        throw new ConflictException(
+          `Device with UID ${createDeviceDto.uid} already exists`,
+        );
+      }
+
+      // Verify device type exists
+      const deviceType = await this.deviceTypeRepository.findOne({
+        where: { id: createDeviceDto.device_type_id },
+      });
+      if (!deviceType) {
+        throw new NotFoundException(
+          `Device type with ID ${createDeviceDto.device_type_id} not found`,
+        );
+      }
+
+      const device = this.deviceRepository.create(createDeviceDto);
+      const savedDevice = await this.deviceRepository.save(device);
+      return this.toResponseDto(savedDevice);
+    } catch (error) {
+      if (
+        error instanceof ConflictException ||
+        error instanceof NotFoundException
+      ) {
+        throw error;
+      }
+      throw new Error('Unexpected error');
+    }
+  }
+
+  async updateDevice(
+    id: string,
+    updateDeviceDto: UpdateDeviceDto,
+  ): Promise<DeviceResponseDto> {
+    try {
+      const device = await this.deviceRepository.findOne({ where: { id } });
+      if (!device) {
+        throw new NotFoundException(`Device with ID ${id} not found`);
+      }
+
+      // Update device properties
+      Object.assign(device, updateDeviceDto);
+      const updatedDevice = await this.deviceRepository.save(device);
+      return this.toResponseDto(updatedDevice);
+    } catch (error) {
+      if (
+        error instanceof ConflictException ||
+        error instanceof NotFoundException
+      ) {
+        throw error;
+      }
+      throw new Error('Unexpected error');
+    }
+  }
+
+  async deleteDevice(id: string): Promise<void> {
+    try {
+      const device = await this.deviceRepository.findOne({ where: { id } });
+      if (!device) {
+        throw new NotFoundException(`Device with ID ${id} not found`);
+      }
+      await this.deviceRepository.remove(device);
+    } catch (error) {
+      if (
+        error instanceof ConflictException ||
+        error instanceof NotFoundException
+      ) {
+        throw error;
+      }
+      throw new Error('Unexpected error');
+    }
+  }
+
+  async getAllDevices(): Promise<DeviceResponseDto[]> {
+    const devices = await this.deviceRepository.find({
+      order: { created_at: 'DESC' },
+    });
+    return devices.map((device) => this.toResponseDto(device));
+  }
+
+  async getDeviceById(id: string): Promise<DeviceResponseDto> {
+    const device = await this.deviceRepository.findOne({ where: { id } });
+    if (!device) {
+      throw new NotFoundException(`Device with ID ${id} not found`);
+    }
+    return this.toResponseDto(device);
+  }
+
+  async getDevicesByGateway(gatewayId: string): Promise<DeviceResponseDto[]> {
+    const devices = await this.deviceRepository.find({
+      where: { gateway_id: gatewayId },
+      order: { created_at: 'DESC' },
+    });
+    return devices.map((device) => this.toResponseDto(device));
+  }
+
+  private toResponseDto(device: PeripheralDevice): DeviceResponseDto {
+    return {
+      id: device.id,
+      uid: device.uid,
+      vendor: device.vendor,
+      status: device.status,
+      created_at: device.created_at,
+      last_seen_at: device.last_seen_at,
+      gateway_id: device.gateway_id,
+      device_type_id: device.device_type_id,
+    };
+  }
+}


### PR DESCRIPTION
This pull request introduces comprehensive support for managing peripheral devices in the codebase. It adds DTOs for device input and output, implements a dedicated `DeviceService` with full CRUD operations, and exposes these DTOs for use throughout the application. The changes are grouped below by theme.

**Device Service Implementation**

* Added `DeviceService` in `src/services/device.service.ts` with methods for adding, updating, deleting, and retrieving devices, including error handling for conflicts and missing entities.

**DTOs for Device Management**

* Created `CreateDeviceDto` and `UpdateDeviceDto` in `src/dtos/device-input.dto.ts` to validate input data for device creation and updates.
* Added output DTOs in `src/dtos/device-response.dto.ts` (`DeviceResponseDto`, `DeviceWithTypeResponseDto`, `DeviceWithGatewayResponseDto`) to standardize device response formats, including device type and gateway details.

**Exports and Integration**

* Exported the new device DTOs in `src/dtos/index.ts` to make them available for use in other modules.