### PR TITLE
Feat/device with gateway

### DIFF
--- a/src/services/gateway.service.ts
+++ b/src/services/gateway.service.ts
@@ -134,7 +134,7 @@ export class GatewayService {
     }
   }
 
-  async addDevice(
+  async addDeviceWithGateway(
     gatewayId: string,
     deviceId: string,
   ): Promise<GatewayResponseDto> {
@@ -183,7 +183,7 @@ export class GatewayService {
     }
   }
 
-  async removeDevice(
+  async removeDeviceWithGateway(
     gatewayId: string,
     deviceId: string,
   ): Promise<GatewayResponseDto> {


### PR DESCRIPTION
This pull request adds new functionality to the `GatewayService` for managing peripheral devices associated with gateways. The most significant changes are the addition of methods to attach and detach devices to gateways, enforcing device limits, and updating logs accordingly. These improvements enhance the service's ability to manage gateway-device relationships and maintain audit trails.

### Device Management Enhancements

* Added `addDeviceWithGateway` method to allow attaching a device to a gateway, including checks for device existence, gateway existence, device assignment status, and a maximum of 10 devices per gateway. Also creates a log entry for the attachment.
* Added `removeDeviceWithGateway` method to detach a device from a gateway, including checks for device existence and assignment, and creates a log entry for the detachment.

### Dependency Injection Updates

* Injected the `PeripheralDevice` repository into the `GatewayService` constructor to support device management operations.

### Entity Import Updates

* Imported the `PeripheralDevice` entity in `gateway.service.ts` to enable device-related operations.